### PR TITLE
Failure in lang row parent id during en row term id change

### DIFF
--- a/src/actions/new.py
+++ b/src/actions/new.py
@@ -131,6 +131,8 @@ class New:
         """
 
         for _, en_row in self.__new_en_rows.iterrows():
+            # set en row lang to en
+            en_row[COLUMNS["lang"]] = "en"
             en_row = self.__set_en_row(en_row)
             self.__create_lang_rows(en_row)
         return self.__database

--- a/src/actions/new_term.py
+++ b/src/actions/new_term.py
@@ -75,15 +75,16 @@ class NewTerm:
 
         old_lang_rows = Get.lang_rows_by_en(self.__database, old_en_row)
         for _, old_lang_row in old_lang_rows.iterrows():
-            new_lang_row = old_lang_row.copy()
-            new_lang_row[COLUMNS["code_id"]] = Get.next_codeid(self.__database)
-            new_lang_row = Set.lang_row_concept_columns(
-                new_lang_row, new_en_row)
-            new_lang_row = Set.lang_administrative(
-                new_en_row, new_lang_row, ADMINISTRATIVE_COLUMNS)
             # check if the old lang row term id is the same as the old en row term id
             # if it is, set the new lang row term and term ids to the new en row term ids
             if old_lang_row[COLUMNS["legacy_term_id"]] == old_en_row[COLUMNS["legacy_term_id"]]:
+                new_lang_row = old_lang_row.copy()
+                new_lang_row[COLUMNS["code_id"]] = Get.next_codeid(self.__database)
+                new_lang_row = Set.lang_row_concept_columns(
+                    new_lang_row, new_en_row)
+                new_lang_row = Set.lang_administrative(
+                    new_en_row, new_lang_row, ADMINISTRATIVE_COLUMNS)
+            
                 new_lang_row[COLUMNS["legacy_term_id"]
                              ] = new_en_row[COLUMNS["legacy_term_id"]]
                 new_lang_row[COLUMNS["term_id"]
@@ -96,6 +97,12 @@ class NewTerm:
                 # add the new lang row to the database
                 self.__database = Post.new_row_to_database_table(
                     new_lang_row, self.__database)
+            else:
+                # if the old lang row term id is not the same as the old en row term id
+                # change only the COLUMNS["en_row_code_id"] = new_en_row code_id
+                self.__database = Put.lang_row_en_row_code_id(
+                    old_lang_row[COLUMNS["code_id"]], self.__database, new_en_row[COLUMNS["code_id"]])
+
 
     def commit(self) -> 'pd.DataFrame':
         """Main function

--- a/src/main/check.py
+++ b/src/main/check.py
@@ -23,7 +23,16 @@ class Check:
         Valid values include: A, C, D, M, T
         """
 
-        return df[~df[COLUMNS["tmdc"]].str[0].isin(['A', 'C', 'D', 'M', 'T'])], "Invalid tmdc, must start with A, C, D, M or T"
+        # Check if tmdc is empty
+        empty_tmdc = df[df[COLUMNS["tmdc"]].isna()]
+
+        # Check if tmdc starts with a valid character
+        invalid_tmdc = df[~df[COLUMNS["tmdc"]].str[0].isin(['A', 'C', 'D', 'M', 'T'])]
+
+        # Concatenate the two dataframes
+        result = pd.concat([empty_tmdc, invalid_tmdc])
+
+        return result, "Invalid tmdc, must be non-empty and start with A, C, D, M or T"
 
     @staticmethod
     def lang(df):
@@ -173,8 +182,6 @@ class Check:
             if len(concept_rows[COLUMNS["concept_fsn"]].unique()) > 1:
                 overlapping_rows = pd.concat([overlapping_rows, concept_rows])
             elif len(concept_rows[COLUMNS["legacy_concept_id"]].unique()) > 1:
-                overlapping_rows = pd.concat([overlapping_rows, concept_rows])
-            elif len(concept_rows[COLUMNS["tmdc"]].str[0].unique()) > 1:
                 overlapping_rows = pd.concat([overlapping_rows, concept_rows])
         return overlapping_rows, "Concept id overlap"
 

--- a/src/services/components/put.py
+++ b/src/services/components/put.py
@@ -99,3 +99,19 @@ class Put:
         for column in administrative_columns:
             database.loc[index, column] = en_row[column]
         return database
+    
+    @staticmethod
+    def lang_row_en_row_code_id(code_id: int, database: 'pd.DataFrame', en_row_code_id: int) -> 'pd.DataFrame':
+        """Updates the en row code id of a lang row in the database
+
+        Args:
+            code_id (int): The code id of the row to be updated
+            database (pd.DataFrame): The database
+            en_row_code_id (int): The en row code id
+
+        Returns:
+            pd.DataFrame: The updated database
+        """
+        index = Get.index_by_codeid(database, code_id)
+        database.loc[index, COLUMNS["en_row_code_id"]] = en_row_code_id
+        return database


### PR DESCRIPTION
During the en row term id change, lang rows with different terms did not change the parent id to the new en row with the updated term.