### PR TITLE
Fix: Lang rows with different term_id

### DIFF
--- a/src/actions/new_term.py
+++ b/src/actions/new_term.py
@@ -39,7 +39,7 @@ class NewTerm:
         Returns:
             pd.Series: The new en row
         """
-        
+
         new_en_row = Set.en_row_code_id(new_en_row, self.__database)
         new_en_row = Set.date(new_en_row, self.__config)
         new_en_row = Set.administrative(new_en_row, old_en_row, self.__config)
@@ -79,12 +79,13 @@ class NewTerm:
             # if it is, set the new lang row term and term ids to the new en row term ids
             if old_lang_row[COLUMNS["legacy_term_id"]] == old_en_row[COLUMNS["legacy_term_id"]]:
                 new_lang_row = old_lang_row.copy()
-                new_lang_row[COLUMNS["code_id"]] = Get.next_codeid(self.__database)
+                new_lang_row[COLUMNS["code_id"]
+                             ] = Get.next_codeid(self.__database)
                 new_lang_row = Set.lang_row_concept_columns(
                     new_lang_row, new_en_row)
                 new_lang_row = Set.lang_administrative(
                     new_en_row, new_lang_row, ADMINISTRATIVE_COLUMNS)
-            
+
                 new_lang_row[COLUMNS["legacy_term_id"]
                              ] = new_en_row[COLUMNS["legacy_term_id"]]
                 new_lang_row[COLUMNS["term_id"]
@@ -100,9 +101,11 @@ class NewTerm:
             else:
                 # if the old lang row term id is not the same as the old en row term id
                 # change only the COLUMNS["en_row_code_id"] = new_en_row code_id
-                self.__database = Put.lang_row_en_row_code_id(
-                    old_lang_row[COLUMNS["code_id"]], self.__database, new_en_row[COLUMNS["code_id"]])
-
+                # self.__database = Put.lang_row_en_row_code_id(
+                #    old_lang_row[COLUMNS["code_id"]], self.__database, new_en_row[COLUMNS["code_id"]])
+                # and update the beginning date to match the new en row
+                self.__database = Put.lang_row_en_row_code_id_with_beginning_date(
+                    old_lang_row[COLUMNS["code_id"]], self.__database, new_en_row[COLUMNS["code_id"]], self.__config.version_date)
 
     def commit(self) -> 'pd.DataFrame':
         """Main function

--- a/src/actions/new_term.py
+++ b/src/actions/new_term.py
@@ -104,8 +104,22 @@ class NewTerm:
                 # self.__database = Put.lang_row_en_row_code_id(
                 #    old_lang_row[COLUMNS["code_id"]], self.__database, new_en_row[COLUMNS["code_id"]])
                 # and update the beginning date to match the new en row
-                self.__database = Put.lang_row_en_row_code_id_with_beginning_date(
-                    old_lang_row[COLUMNS["code_id"]], self.__database, new_en_row[COLUMNS["code_id"]], self.__config.version_date)
+                #self.__database = Put.lang_row_en_row_code_id_with_beginning_date(
+                #    old_lang_row[COLUMNS["code_id"]], self.__database, new_en_row[COLUMNS["code_id"]], self.__config.version_date)
+                               # keep the term data, but inactivate the old row and create a new one
+                new_lang_row = old_lang_row.copy()
+                new_lang_row[COLUMNS["code_id"]] = Get.next_codeid(self.__database)
+                new_lang_row = Set.lang_row_concept_columns(
+                    new_lang_row, new_en_row)
+                new_lang_row = Set.lang_administrative(
+                    new_en_row, new_lang_row, ADMINISTRATIVE_COLUMNS)
+                new_lang_row = Set.date(new_lang_row, self.__config)
+                # inactivate the old lang row
+                self.__database = Put.inactivate_row(old_lang_row[COLUMNS["code_id"]], self.__database, self.__config.version_date,
+                                                     old_en_row[COLUMNS["inaktivoinnin_selite"]], old_en_row[COLUMNS["edit_comment"]], new_lang_row[COLUMNS["code_id"]])
+                # add the new lang row to the database
+                self.__database = Post.new_row_to_database_table(
+                    new_lang_row, self.__database)
 
     def commit(self) -> 'pd.DataFrame':
         """Main function

--- a/src/services/components/put.py
+++ b/src/services/components/put.py
@@ -115,3 +115,22 @@ class Put:
         index = Get.index_by_codeid(database, code_id)
         database.loc[index, COLUMNS["en_row_code_id"]] = en_row_code_id
         return database
+    
+
+    @staticmethod
+    def lang_row_en_row_code_id_with_beginning_date(code_id: int, database: 'pd.DataFrame', en_row_code_id: int, beginning_date: str) -> 'pd.DataFrame':
+        """Updates the en row code id and beginning date of a lang row in the database
+
+        Args:
+            code_id (int): The code id of the row to be updated
+            database (pd.DataFrame): The database
+            en_row_code_id (int): The en row code id
+            beginning_date (str): The new beginning date
+
+        Returns:
+            pd.DataFrame: The updated database
+        """
+        index = Get.index_by_codeid(database, code_id)
+        database.loc[index, COLUMNS["en_row_code_id"]] = en_row_code_id
+        database.loc[index, COLUMNS["beginning_date"]] = beginning_date
+        return database


### PR DESCRIPTION
When an en_row termid is updated, the lang_row with different ids did not get new rows; they just pointed to the new_en_row. Now, even though the term of the lang row does not change, new rows are created for the new en row id. This was to fix an issue where the old style caused problems in the THL CodeServer.